### PR TITLE
Add Randomize Height Changes and Break Joints to  Observation Space and add Flags Germane to Changes in Experimentation / Robot

### DIFF
--- a/legged_gym/envs/base/base_task.py
+++ b/legged_gym/envs/base/base_task.py
@@ -59,15 +59,19 @@ class BaseTask():
 
         self.num_envs = cfg.env.num_envs
         self.num_obs = cfg.env.num_observations
-        if cfg.domain_rand.randomize_base_mass and cfg.domain_rand.randomize_link_mass:
+        if cfg.domain_rand.randomize_base_mass_add_obs and cfg.domain_rand.randomize_link_mass_add_obs:
             random_mass_change_size = 18
-        elif cfg.domain_rand.randomize_base_mass:
+        elif cfg.domain_rand.randomize_base_mass_add_obs:
             random_mass_change_size =  1
-        elif cfg.domain_rand.randomize_link_mass:
+        elif cfg.domain_rand.randomize_link_mass_add_obs:
             random_mass_change_size =  17
         else:
             random_mass_change_size =  0
-        self.num_obs += random_mass_change_size
+        if cfg.control.break_joints_add_obs:
+            break_joints_size = 12
+        else:
+            break_joints_size = 0
+        self.num_obs += random_mass_change_size + break_joints_size
         self.num_privileged_obs = cfg.env.num_privileged_obs
         self.num_actions = cfg.env.num_actions
 

--- a/legged_gym/envs/base/base_task.py
+++ b/legged_gym/envs/base/base_task.py
@@ -71,7 +71,11 @@ class BaseTask():
             break_joints_size = 12
         else:
             break_joints_size = 0
-        self.num_obs += random_mass_change_size + break_joints_size
+        if cfg.terrain.measure_heights:
+            measure_height_size = 0
+        else:
+            measure_height_size = -187
+        self.num_obs += random_mass_change_size + break_joints_size + measure_height_size
         self.num_privileged_obs = cfg.env.num_privileged_obs
         self.num_actions = cfg.env.num_actions
 

--- a/legged_gym/envs/base/base_task.py
+++ b/legged_gym/envs/base/base_task.py
@@ -95,7 +95,6 @@ class BaseTask():
             self.privileged_obs_buf = None
             # self.num_privileged_obs = self.num_obs
 
-        # buffers? tensor for random_mass_change
         self.random_mass_change = torch.zeros(self.num_envs, random_mass_change_size, dtype=torch.float, device=self.device, requires_grad=False)  
 
         self.extras = {}

--- a/legged_gym/envs/base/base_task.py
+++ b/legged_gym/envs/base/base_task.py
@@ -60,6 +60,7 @@ class BaseTask():
         self.num_envs = cfg.env.num_envs
         self.num_obs = cfg.env.num_observations
         if (cfg.domain_rand.randomize_base_mass or cfg.domain_rand.randomize_link_mass):
+            # TODO: Write this in another file specific for a1
             self.num_obs += 16 # Is this the best way to add observations? Do I need to add observation number?
         self.num_privileged_obs = cfg.env.num_privileged_obs
         self.num_actions = cfg.env.num_actions

--- a/legged_gym/envs/base/base_task.py
+++ b/legged_gym/envs/base/base_task.py
@@ -59,6 +59,8 @@ class BaseTask():
 
         self.num_envs = cfg.env.num_envs
         self.num_obs = cfg.env.num_observations
+        if (cfg.domain_rand.randomize_base_mass or cfg.domain_rand.randomize_link_mass):
+            self.num_obs += 16 # Is this the best way to add observations? Do I need to add observation number?
         self.num_privileged_obs = cfg.env.num_privileged_obs
         self.num_actions = cfg.env.num_actions
 

--- a/legged_gym/envs/base/base_task.py
+++ b/legged_gym/envs/base/base_task.py
@@ -59,9 +59,15 @@ class BaseTask():
 
         self.num_envs = cfg.env.num_envs
         self.num_obs = cfg.env.num_observations
-        if (cfg.domain_rand.randomize_base_mass or cfg.domain_rand.randomize_link_mass):
-            # TODO: Write this in another file specific for a1
-            self.num_obs += 16 # Is this the best way to add observations? Do I need to add observation number?
+        if cfg.domain_rand.randomize_base_mass and cfg.domain_rand.randomize_link_mass:
+            random_mass_change_size += 18
+        elif cfg.domain_rand.randomize_base_mass:
+            random_mass_change_size +=  1
+        elif cfg.domain_rand.randomize_link_mass:
+            random_mass_change_size +=  17
+        else:
+            random_mass_change_size +=  0
+        self.num_obs += random_mass_change_size
         self.num_privileged_obs = cfg.env.num_privileged_obs
         self.num_actions = cfg.env.num_actions
 
@@ -80,6 +86,9 @@ class BaseTask():
         else: 
             self.privileged_obs_buf = None
             # self.num_privileged_obs = self.num_obs
+
+        # buffers? tensor for random_mass_change
+        self.random_mass_change = torch.zeros(self.num_envs, random_mass_change_size, dtype=torch.float, device=self.device, requires_grad=False)  
 
         self.extras = {}
 

--- a/legged_gym/envs/base/base_task.py
+++ b/legged_gym/envs/base/base_task.py
@@ -60,13 +60,13 @@ class BaseTask():
         self.num_envs = cfg.env.num_envs
         self.num_obs = cfg.env.num_observations
         if cfg.domain_rand.randomize_base_mass and cfg.domain_rand.randomize_link_mass:
-            random_mass_change_size += 18
+            random_mass_change_size = 18
         elif cfg.domain_rand.randomize_base_mass:
-            random_mass_change_size +=  1
+            random_mass_change_size =  1
         elif cfg.domain_rand.randomize_link_mass:
-            random_mass_change_size +=  17
+            random_mass_change_size =  17
         else:
-            random_mass_change_size +=  0
+            random_mass_change_size =  0
         self.num_obs += random_mass_change_size
         self.num_privileged_obs = cfg.env.num_privileged_obs
         self.num_actions = cfg.env.num_actions

--- a/legged_gym/envs/base/legged_robot.py
+++ b/legged_gym/envs/base/legged_robot.py
@@ -502,12 +502,16 @@ class LeggedRobot(BaseTask):
         noise_vec[12:24] = noise_scales.dof_pos * noise_level * self.obs_scales.dof_pos
         noise_vec[24:36] = noise_scales.dof_vel * noise_level * self.obs_scales.dof_vel
         noise_vec[36:48] = 0. # previous actions
+        next_elem = 48
         if self.cfg.terrain.measure_heights:
-            noise_vec[48:235] = noise_scales.height_measurements* noise_level * self.obs_scales.height_measurements
+            noise_vec[next_elem:next_elem+187] = noise_scales.height_measurements* noise_level * self.obs_scales.height_measurements
+            next_elem += 187
         if self.cfg.domain_rand.randomize_base_mass_add_obs: # 1 Added due to trunk / base mass change
-            noise_vec[235:236] = noise_scales.base_mass_change * noise_level * self.obs_scales.base_mass_change
+            noise_vec[next_elem:next_elem+1] = noise_scales.base_mass_change * noise_level * self.obs_scales.base_mass_change
+            next_elem += 1
         if self.cfg.domain_rand.randomize_link_mass_add_obs: # 17 Added due to link masses change
-            noise_vec[236:253] = noise_scales.link_mass_change * noise_level * self.obs_scales.link_mass_change
+            noise_vec[next_elem:next_elem+17] = noise_scales.link_mass_change * noise_level * self.obs_scales.link_mass_change
+            next_elem += 17
         if self.cfg.control.break_joints_add_obs: # 4 Added due to adding bit mask for joint breakage of 4 possible joints
             pass # No real point in adding noise to joint breakage
         return noise_vec
@@ -741,7 +745,7 @@ class LeggedRobot(BaseTask):
         for i in range(len(termination_contact_names)):
             self.termination_contact_indices[i] = self.gym.find_actor_rigid_body_handle(self.envs[0], self.actor_handles[0], termination_contact_names[i])
         
-        self.random_mass_change_copy = torch.clone(self.breakage_mask).requires_grad_(True)
+        self.random_mass_change_copy = torch.clone(self.random_mass_change).requires_grad_(True)
 
     def _get_env_origins(self):
         """ Sets environment origins. On rough terrain the origins are defined by the terrain platforms.

--- a/legged_gym/envs/base/legged_robot.py
+++ b/legged_gym/envs/base/legged_robot.py
@@ -542,7 +542,7 @@ class LeggedRobot(BaseTask):
         self.last_dof_vel = torch.zeros_like(self.dof_vel)
         self.last_root_vel = torch.zeros_like(self.root_states[:, 7:13])
         self.commands = torch.zeros(self.num_envs, self.cfg.commands.num_commands, dtype=torch.float, device=self.device, requires_grad=False) # x vel, y vel, yaw vel, heading
-        self.commands_scale = torch.tensor([self.obs_scales.lin_vel, self.obs_scales.lin_vel, self.obs_scales.ang_vel], device=self.device, requires_grad=False,) 
+        self.commands_scale = torch.tensor([self.obs_scales.lin_vel, self.obs_scales.lin_vel, self.obs_scales.ang_vel], device=self.device, requires_grad=False,) # TODO change this
         self.feet_air_time = torch.zeros(self.num_envs, self.feet_indices.shape[0], dtype=torch.float, device=self.device, requires_grad=False)
         self.last_contacts = torch.zeros(self.num_envs, len(self.feet_indices), dtype=torch.bool, device=self.device, requires_grad=False)
         self.base_lin_vel = quat_rotate_inverse(self.base_quat, self.root_states[:, 7:10])
@@ -577,7 +577,6 @@ class LeggedRobot(BaseTask):
             for i in range(self.cfg.env.num_envs):
                 break_joint = random.randint(8, 11)
                 self.breakage_mask[i, break_joint] = 0
-        self.breakage_mask_copy = torch.clone(self.breakage_mask).requires_grad_(True)
 
     def _prepare_reward_function(self):
         """ Prepares a list of reward functions, whcih will be called to compute the total reward.
@@ -736,8 +735,6 @@ class LeggedRobot(BaseTask):
         for i in range(len(termination_contact_names)):
             self.termination_contact_indices[i] = self.gym.find_actor_rigid_body_handle(self.envs[0], self.actor_handles[0], termination_contact_names[i])
         
-        self.random_mass_change_copy = torch.clone(self.random_mass_change).requires_grad_(True)
-
     def _get_env_origins(self):
         """ Sets environment origins. On rough terrain the origins are defined by the terrain platforms.
             Otherwise create a grid.

--- a/legged_gym/envs/base/legged_robot.py
+++ b/legged_gym/envs/base/legged_robot.py
@@ -223,11 +223,12 @@ class LeggedRobot(BaseTask):
             heights = torch.clip(self.root_states[:, 2].unsqueeze(1) - 0.5 - self.measured_heights, -1, 1.) * self.obs_scales.height_measurements
             self.obs_buf = torch.cat((self.obs_buf, heights), dim=-1)
         if self.cfg.domain_rand.randomize_base_mass or self.cfg.domain_rand.randomize_link_mass:
-            print(self.obs_buf.size())
-            print(self.random_mass_change.size())
+            print("Observation Buffer Size Before adding Randomize Base/Link Mass: ", self.obs_buf.size())
+            print("Random Mass Change Size Before adding Randomize Base/Link Mass: ", self.random_mass_change.size())
             self.obs_buf = torch.cat((self.obs_buf, self.random_mass_change), dim=-1)
         # add noise if needed
         if self.add_noise:
+            print("Observation Buffer Size Before adding Noise: ", self.obs_buf.size())
             self.obs_buf += (2 * torch.rand_like(self.obs_buf) - 1) * self.noise_scale_vec # Giving the most problem because it uses 235, the size without the random mass
             print(self.obs_buf.size())
 
@@ -733,6 +734,8 @@ class LeggedRobot(BaseTask):
         self.termination_contact_indices = torch.zeros(len(termination_contact_names), dtype=torch.long, device=self.device, requires_grad=False)
         for i in range(len(termination_contact_names)):
             self.termination_contact_indices[i] = self.gym.find_actor_rigid_body_handle(self.envs[0], self.actor_handles[0], termination_contact_names[i])
+        
+        self.random_mass_change_copy = torch.clone(self.breakage_mask).requires_grad_(True)
 
     def _get_env_origins(self):
         """ Sets environment origins. On rough terrain the origins are defined by the terrain platforms.

--- a/legged_gym/envs/base/legged_robot.py
+++ b/legged_gym/envs/base/legged_robot.py
@@ -320,17 +320,6 @@ class LeggedRobot(BaseTask):
         #     print(f"Total mass {sum} (before randomization)")
         # randomize base mass
 
-        if self.cfg.domain_rand.randomize_base_mass and self.cfg.domain_rand.randomize_link_mass:
-            random_mass_change_size = 18
-        elif self.cfg.domain_rand.randomize_base_mass:
-            random_mass_change_size = 1
-        elif self.cfg.domain_rand.randomize_link_mass:
-            random_mass_change_size = 17
-        else:
-            random_mass_change_size = 0
-
-        self.random_mass_change = torch.zeros(self.num_envs, random_mass_change_size, dtype=torch.float, device=self.device, requires_grad=False)  
-
         # NOTE: Does 0 and refer to the base mass of the robot, and not com
         # props[0].mass would refer to center of mass
         if self.cfg.domain_rand.randomize_base_mass:
@@ -586,6 +575,7 @@ class LeggedRobot(BaseTask):
             for i in range(self.cfg.env.num_envs):
                 break_joint = random.randint(8, 11)
                 self.breakage_mask[i, break_joint] = 0
+        self.breakage_mask_copy = torch.clone(self.breakage_mask).requires_grad_(True)
 
     def _prepare_reward_function(self):
         """ Prepares a list of reward functions, whcih will be called to compute the total reward.

--- a/legged_gym/envs/base/legged_robot.py
+++ b/legged_gym/envs/base/legged_robot.py
@@ -326,13 +326,13 @@ class LeggedRobot(BaseTask):
             rng_range = self.cfg.domain_rand.added_base_mass_range
             rng = np.random.uniform(rng_range[0], rng_range[1])
             props[0].mass += rng
-            self.random_mass_change[0] = props[0].mass
+            self.random_mass_change[env_id][0] = props[0].mass
         if self.cfg.domain_rand.randomize_link_mass:
             for i in (2, 3, 6, 7, 10, 11, 14, 15):
                 rng_range = self.cfg.domain_rand.added_link_mass_range
                 rng = np.random.uniform(rng_range[0], rng_range[1])
                 props[i].mass *= rng
-                self.random_mass_change[i] = props[i].mass
+                self.random_mass_change[env_id][i] = props[i].mass
 
         return props
     

--- a/legged_gym/envs/base/legged_robot.py
+++ b/legged_gym/envs/base/legged_robot.py
@@ -478,7 +478,6 @@ class LeggedRobot(BaseTask):
             self.command_ranges["lin_vel_x"][1] = np.clip(self.command_ranges["lin_vel_x"][1] + 0.5, 0., self.cfg.commands.max_curriculum)
 
 
-    # TODO: Make a1 class that extends this and use that to write a new get noise scale vec function, if we want to use noise in our experiments
     def _get_noise_scale_vec(self, cfg):
         """ Sets a vector used to scale the noise added to the observations.
             [NOTE]: Must be adapted when changing the observations structure
@@ -502,6 +501,12 @@ class LeggedRobot(BaseTask):
         noise_vec[36:48] = 0. # previous actions
         if self.cfg.terrain.measure_heights:
             noise_vec[48:235] = noise_scales.height_measurements* noise_level * self.obs_scales.height_measurements
+        if self.cfg.domain_rand.randomize_base_mass: # 1 Added due to trunk / base mass change
+            noise_vec[235:236] = noise_scales.base_mass_change * noise_level * self.obs_scales.base_mass_change
+        if self.cfg.domain_rand.randomize_link_mass: # 17 Added due to link masses change
+            noise_vec[236:253] = noise_scales.link_mass_change * noise_level * self.obs_scales.link_mass_change
+        if self.cfg.control.break_joints: # 4 Added due to adding bit mask for joint breakage of 4 possible joints
+            pass # No real point in adding noise to joint breakage
         return noise_vec
 
     #----------------------------------------

--- a/legged_gym/envs/base/legged_robot.py
+++ b/legged_gym/envs/base/legged_robot.py
@@ -222,13 +222,14 @@ class LeggedRobot(BaseTask):
         if self.cfg.terrain.measure_heights:
             heights = torch.clip(self.root_states[:, 2].unsqueeze(1) - 0.5 - self.measured_heights, -1, 1.) * self.obs_scales.height_measurements
             self.obs_buf = torch.cat((self.obs_buf, heights), dim=-1)
-        # add noise if needed
-        if self.add_noise:
-            self.obs_buf += (2 * torch.rand_like(self.obs_buf) - 1) * self.noise_scale_vec # Giving the most problem because it uses 235, the size without the random mass
         if self.cfg.domain_rand.randomize_base_mass or self.cfg.domain_rand.randomize_link_mass:
             print(self.obs_buf.size())
             print(self.random_mass_change.size())
             self.obs_buf = torch.cat((self.obs_buf, self.random_mass_change), dim=-1)
+        # add noise if needed
+        if self.add_noise:
+            self.obs_buf += (2 * torch.rand_like(self.obs_buf) - 1) * self.noise_scale_vec # Giving the most problem because it uses 235, the size without the random mass
+            print(self.obs_buf.size())
 
 
     def create_sim(self):

--- a/legged_gym/envs/base/legged_robot_config.py
+++ b/legged_gym/envs/base/legged_robot_config.py
@@ -165,8 +165,8 @@ class LeggedRobotCfg(BaseConfig):
             dof_pos = 1.0
             dof_vel = 0.05
             height_measurements = 5.0
-            base_mass_change = 1.0
-            link_mass_change = 1.0
+            base_mass_change = 1.0 # TODO: Make sure this is calibrated properly
+            link_mass_change = 1.0 # TODO: Make sure this is calibrated properly
 
         clip_observations = 100.
         clip_actions = 100.
@@ -181,8 +181,8 @@ class LeggedRobotCfg(BaseConfig):
             ang_vel = 0.2
             gravity = 0.05
             height_measurements = 0.1
-            base_mass_change = 0.1
-            link_mass_change = 0.1
+            base_mass_change = 0.1 # TODO: Make sure this is calibrated properly
+            link_mass_change = 0.1 # TODO: Make sure this is calibrated properly
 
     # viewer camera:
     class viewer:

--- a/legged_gym/envs/base/legged_robot_config.py
+++ b/legged_gym/envs/base/legged_robot_config.py
@@ -50,7 +50,7 @@ class LeggedRobotCfg(BaseConfig):
         dynamic_friction = 1.0
         restitution = 0.
         # rough terrain only:
-        measure_heights = True
+        measure_heights = False
         measured_points_x = [-0.8, -0.7, -0.6, -0.5, -0.4, -0.3, -0.2, -0.1, 0., 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8] # 1mx1.6m rectangle (without center line)
         measured_points_y = [-0.5, -0.4, -0.3, -0.2, -0.1, 0., 0.1, 0.2, 0.3, 0.4, 0.5]
         selected = False # select a unique terrain type and pass all arguments

--- a/legged_gym/envs/base/legged_robot_config.py
+++ b/legged_gym/envs/base/legged_robot_config.py
@@ -165,6 +165,9 @@ class LeggedRobotCfg(BaseConfig):
             dof_pos = 1.0
             dof_vel = 0.05
             height_measurements = 5.0
+            base_mass_change = 1.0
+            link_mass_change = 1.0
+
         clip_observations = 100.
         clip_actions = 100.
 
@@ -178,6 +181,8 @@ class LeggedRobotCfg(BaseConfig):
             ang_vel = 0.2
             gravity = 0.05
             height_measurements = 0.1
+            base_mass_change = 0.1
+            link_mass_change = 0.1
 
     # viewer camera:
     class viewer:

--- a/legged_gym/envs/base/legged_robot_config.py
+++ b/legged_gym/envs/base/legged_robot_config.py
@@ -97,6 +97,7 @@ class LeggedRobotCfg(BaseConfig):
         decimation = 4
         # break_joints: Randomly disable calf joints (1 of the legs for each robot)
         break_joints = False
+        break_joints_add_obs = False
 
     class asset:
         file = ""
@@ -125,6 +126,8 @@ class LeggedRobotCfg(BaseConfig):
         friction_range = [0.5, 1.25]
         randomize_base_mass = False
         randomize_link_mass = False
+        randomize_base_mass_add_obs = False
+        randomize_link_mass_add_obs = False
         added_base_mass_range = [-1., 1.]
         added_link_mass_range = [0.8, 1.2]
         push_robots = True

--- a/legged_gym/utils/helpers.py
+++ b/legged_gym/utils/helpers.py
@@ -132,14 +132,20 @@ def update_cfg_from_args(env_cfg, cfg_train, args):
             env_cfg.env.num_envs = args.num_envs
         if args.randomize_base_mass is not None:
             env_cfg.domain_rand.randomize_base_mass = args.randomize_base_mass
+        if args.randomize_base_mass_add_observations is not None:
+            env_cfg.domain_rand.randomize_base_mass_add_obs = args.randomize_base_mass_add_observations
         if args.randomize_base_mass_range is not None:
             env_cfg.domain_rand.added_base_mass_range = [float(num) for num in args.randomize_base_mass_range.split(',')] 
         if args.randomize_link_mass is not None:
             env_cfg.domain_rand.randomize_link_mass = args.randomize_link_mass
+        if args.randomize_link_mass_add_observations is not None:
+            env_cfg.domain_rand.randomize_link_mass_add_obs = args.randomize_link_mass_add_observations
         if args.randomize_link_mass_range is not None:
             env_cfg.domain_rand.added_link_mass_range = [float(num) for num in args.randomize_link_mass_range.split(',')] 
         if args.break_joints is not None:
             env_cfg.control.break_joints = args.break_joints
+        if args.break_joints_add_observations is not None:
+            env_cfg.control.break_joints_add_obs = args.break_joints_add_observations
     if cfg_train is not None:
         if args.seed is not None:
             cfg_train.seed = args.seed
@@ -183,10 +189,13 @@ def get_args():
         {"name": "--critic_hidden_dims", "type": str, "help": "Defines Critic Hidden Dimensions for Policy."}, # Make more descriptive
 
         {"name": "--randomize_base_mass", "type": bool, "help": "Randomize Base mass based on range specified in configuration or flags."},
+        {"name": "--randomize_base_mass_add_observation", "type": bool, "help": "Add Randomize Base mass to the observation space."},
         {"name": "--randomize_base_mass_range", "type": str, "help": "Range for randomize base mass amount based on proportional value."},
         {"name": "--randomize_link_mass", "type": bool, "help": "Randomize Link mass based on range specified in configuration or flags."},
+        {"name": "--randomize_link_mass_add_observation", "type": bool, "help": "Add Randomize Link mass to the observation space."},
         {"name": "--randomize_link_mass_range", "type": str, "help": "Range for randomize link mass amount based on proportional value."},
         {"name": "--break_joints", "type": bool, "help": "Breaks a random joint."}, # Make more descriptive
+        {"name": "--break_joints_add_observation", "type": bool, "help": "Add Break Joints to the observation space."},
     ]
     # parse arguments
     args = gymutil.parse_arguments(

--- a/legged_gym/utils/helpers.py
+++ b/legged_gym/utils/helpers.py
@@ -132,20 +132,22 @@ def update_cfg_from_args(env_cfg, cfg_train, args):
             env_cfg.env.num_envs = args.num_envs
         if args.randomize_base_mass is not None:
             env_cfg.domain_rand.randomize_base_mass = args.randomize_base_mass
-        if args.randomize_base_mass_add_observations is not None:
-            env_cfg.domain_rand.randomize_base_mass_add_obs = args.randomize_base_mass_add_observations
+        if args.randomize_base_mass_add_observation is not None:
+            env_cfg.domain_rand.randomize_base_mass_add_obs = args.randomize_base_mass_add_observation
         if args.randomize_base_mass_range is not None:
             env_cfg.domain_rand.added_base_mass_range = [float(num) for num in args.randomize_base_mass_range.split(',')] 
         if args.randomize_link_mass is not None:
             env_cfg.domain_rand.randomize_link_mass = args.randomize_link_mass
-        if args.randomize_link_mass_add_observations is not None:
-            env_cfg.domain_rand.randomize_link_mass_add_obs = args.randomize_link_mass_add_observations
+        if args.randomize_link_mass_add_observation is not None:
+            env_cfg.domain_rand.randomize_link_mass_add_obs = args.randomize_link_mass_add_observation
         if args.randomize_link_mass_range is not None:
             env_cfg.domain_rand.added_link_mass_range = [float(num) for num in args.randomize_link_mass_range.split(',')] 
         if args.break_joints is not None:
             env_cfg.control.break_joints = args.break_joints
-        if args.break_joints_add_observations is not None:
-            env_cfg.control.break_joints_add_obs = args.break_joints_add_observations
+        if args.break_joints_add_observation is not None:
+            env_cfg.control.break_joints_add_obs = args.break_joints_add_observation
+        if args.measure_heights is not None:
+            env_cfg.terrain.measure_heights = args.measure_heights
     if cfg_train is not None:
         if args.seed is not None:
             cfg_train.seed = args.seed
@@ -196,6 +198,7 @@ def get_args():
         {"name": "--randomize_link_mass_range", "type": str, "help": "Range for randomize link mass amount based on proportional value."},
         {"name": "--break_joints", "type": bool, "help": "Breaks a random joint."}, # Make more descriptive
         {"name": "--break_joints_add_observation", "type": bool, "help": "Add Break Joints to the observation space."},
+        {"name": "--measure_heights", "type": bool, "help": "Measure heights."},
     ]
     # parse arguments
     args = gymutil.parse_arguments(

--- a/legged_gym/utils/helpers.py
+++ b/legged_gym/utils/helpers.py
@@ -190,15 +190,15 @@ def get_args():
         {"name": "--actor_hidden_dims", "type": str, "help": "Defines Actor Hidden Dimensions for Policy."}, # Make more descriptive
         {"name": "--critic_hidden_dims", "type": str, "help": "Defines Critic Hidden Dimensions for Policy."}, # Make more descriptive
 
-        {"name": "--randomize_base_mass", "type": bool, "help": "Randomize Base mass based on range specified in configuration or flags."},
-        {"name": "--randomize_base_mass_add_observation", "type": bool, "help": "Add Randomize Base mass to the observation space."},
+        {"name": "--randomize_base_mass", "action": "store_true", "default": False, "help": "Randomize Base mass based on range specified in configuration or flags."},
+        {"name": "--randomize_base_mass_add_observation", "action": "store_true", "default": False, "help": "Add Randomize Base mass to the observation space."},
         {"name": "--randomize_base_mass_range", "type": str, "help": "Range for randomize base mass amount based on proportional value."},
-        {"name": "--randomize_link_mass", "type": bool, "help": "Randomize Link mass based on range specified in configuration or flags."},
-        {"name": "--randomize_link_mass_add_observation", "type": bool, "help": "Add Randomize Link mass to the observation space."},
+        {"name": "--randomize_link_mass", "action": "store_true", "default": False, "help": "Randomize Link mass based on range specified in configuration or flags."},
+        {"name": "--randomize_link_mass_add_observation", "action": "store_true", "default": False, "help": "Add Randomize Link mass to the observation space."},
         {"name": "--randomize_link_mass_range", "type": str, "help": "Range for randomize link mass amount based on proportional value."},
-        {"name": "--break_joints", "type": bool, "help": "Breaks a random joint."}, # Make more descriptive
-        {"name": "--break_joints_add_observation", "type": bool, "help": "Add Break Joints to the observation space."},
-        {"name": "--measure_heights", "type": bool, "help": "Measure heights."},
+        {"name": "--break_joints", "action": "store_true", "default": False, "help": "Breaks a random joint."}, # Make more descriptive
+        {"name": "--break_joints_add_observation", "action": "store_true", "default": False, "help": "Add Break Joints to the observation space."},
+        {"name": "--measure_heights", "action": "store_true", "default": False, "help": "Measure heights."},
     ]
     # parse arguments
     args = gymutil.parse_arguments(


### PR DESCRIPTION
In addition to what is mentioned in the commit name, made the observation buffer programmatic, in the sense that it does not depend entirely on static values that would not work with additions to the observation space. While I have not made it entirely programmatic, it's definitely much more malleable compared to the original code base, where measure_heights seemed to be the only room for adding to the observation space. Many flags and options were added so we may change their corresponding properties in our experiments.